### PR TITLE
Switched nginx to map/try_files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,11 @@ With the above in place, access the page and look at the request header appended
 * See list of included server configurations above.
 * Connect middleware (node.js): https://github.com/msemenistyi/connect-image-optimus
 * ... please send a pull request!
+
+## Implementation notes
+
+The concept of Accept negotiations is explained in details in
+[Deploying WebP via Accept Content Negotiation](http://www.igvita.com/2013/05/01/deploying-webp-via-accept-content-negotiation/).
+The current version of a nginx.conf file doesn't use `if` and `rewrite` of the above mentioned
+article opting for `map` and `try_files`. For details, please refer to
+[Serve files with nginx conditionally](http://www.lazutkin.com/blog/2014/02/23/serve-files-with-nginx-conditionally/).

--- a/nginx.conf
+++ b/nginx.conf
@@ -5,6 +5,8 @@ events {
 }
 
 http {
+  # IMPORTANT!!! Make sure that mime.types below lists WebP like that:
+  # image/webp webp;
   include mime.types;
   default_type  application/octet-stream;
 
@@ -15,6 +17,20 @@ http {
   # For a hands-on explanation of using Accept negotiation, see:
   # http://www.igvita.com/2013/05/01/deploying-webp-via-accept-content-negotiation/
 
+  # For an explanation of how to use maps for that, see:
+  # http://www.lazutkin.com/blog/2014/02/23/serve-files-with-nginx-conditionally/
+
+  map $http_accept $webp_suffix {
+    "~*webp"  ".webp";
+  }
+  map $msie $cache_control {
+      "1"     "private";
+  }
+  map $msie $vary_header {
+      default "Accept";
+      "1"     "";
+  }
+
   # if proxying to another backend and using nginx as cache
   proxy_cache_path  /tmp/cache levels=1:2 keys_zone=my-cache:8m max_size=1000m inactive=600m;
   proxy_temp_path /tmp/cache/tmp;
@@ -23,28 +39,21 @@ http {
     listen       8081;
     server_name  localhost;
 
-    # check Accept header for webp, check if .webp is on disk
-    if ($http_accept ~* "webp")    { set $webp_accept "true"; }
-    if (-f $request_filename.webp) { set $webp_local "true";  }
-
     location / {
-      # if WebP variant is available, serve Vary
-      if ($webp_local = "true") {
-        add_header Vary Accept;
-      }
-
-      # if WebP is supported by client, serve it
-      if ($webp_accept = "true") {
-        rewrite (.*) $1.webp break;
-      }
+      # set response headers specially treating MSIE
+      add_header Vary $vary_header;
+      add_header Cache-Control $cache_control;
+      # now serve our images
+      try_files $uri$webp_suffix $uri =404;
     }
 
     # if proxying to another backend and using nginx as cache
+    if ($http_accept ~* "webp")    { set $webp_accept "true"; }
     proxy_cache_key $scheme$proxy_host$request_uri$webp_local$webp_accept;
 
     location /proxy {
       # Pass WebP support header to backend
-      proxy_set_header  WebP  $webp;
+      proxy_set_header  WebP  $webp_accept;
       proxy_pass http://127.0.0.1:8080;
       proxy_cache my-cache;
     }


### PR DESCRIPTION
Sorry for the delay, but better late than never.

Notes:
1. While the original code didn't include a special processing for MSIE, it was mentioned on [Twitter](https://twitter.com/igrigorik/status/525034376665763840), so I added it using your description of a desired functionality in the blog post as a guidance.
   1. `$msie` variable of `ngx_http_browser_module` is used to detect MSIE. The module is included in nginx by default, no need to recompile anything.
   2. `$msie` fails to detect IE11 as MSIE. OTOH, the original code fails to do it as well. Oh, well. If it is critical, we can use a custom detection with a better regular expression.
2. The code doesn't check explicitly if a `.webp` version exists relying on `try_files`. As a side-effect, `Vary: Accept` is set for all modern browsers (excluding MSIE). In my case it is a desirable behavior:
   1. No need to touch a file twice, which speeds up the preferred case of modern browsers supporting WebP.
   2. It rarely makes sense to use WebP selectively. Personally I convert files to WebP automatically en mass anyway.
3. I have no idea about the proxy business, or what it does. Consequently I didn't touch it.
   1. Personally I prefer to serve static assets without extra proxying. If I generate something by an external application, I usually prefer take care of the response there instead of having a response logic all over the place. But who knows what people do. OTOH, we suppose to show best practices.
   2. The proxy code used `$webp` variable, but I couldn't find where it is set. Judging by the context it was supposed to be `$webp_accept`, so I changed it. Please double-check.
4. I added references to relevant blog posts, which explain details.
5. I added a comment advising to add WebP to `mime.types`. This file is not included in the repository, and with the default one, WebP files will be downloaded rather than shown.

Let me know, if you have any suggestions or concerns.
