### PR TITLE
Only try to serve WebP when serving images

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -37,7 +37,7 @@ http {
     listen       8081;
     server_name  localhost;
 
-    location / {
+    location ~ \.(png|jpe?g)$ {
       # set response headers specially treating MSIE
       add_header Vary $vary_header;
       add_header Cache-Control $cache_control;
@@ -49,7 +49,7 @@ http {
     if ($http_accept ~* "webp")    { set $webp_accept "true"; }
     proxy_cache_key $scheme$proxy_host$request_uri$webp_local$webp_accept;
 
-    location /proxy {
+    location ~ ^/proxy.*\.(png|jpe?g)$ {
       # Pass WebP support header to backend
       proxy_set_header  WebP  $webp_accept;
       proxy_pass http://127.0.0.1:8080;


### PR DESCRIPTION
While correct, the previous version was serving a `Vary: Accept`
header for all resources, not just images. This would reduce caching
efficiency for non-image resources. Older versions were testing if a
webp resource was existing. With `try_files`, this is harder to do.
However, to minimize cache miss, we only add `Vary` header for things
looking like images.

Fix #9